### PR TITLE
Implode arrays in send_email

### DIFF
--- a/class.formr.php
+++ b/class.formr.php
@@ -3883,12 +3883,12 @@ class Formr
                     # if key is an array, print all values
 
                     if (is_array($value)) {
-                      $value = implode("; ",$value);
+                        $value = implode(', ',$value);
                     }
 
                     if ($html) {
                         $msg .= "<tr>\r\n";
-                        $msg .= "\t<td><strong>$key</strong></td>\r\n";
+                        $msg .= "\t<td><strong>$key:</strong></td>\r\n";
                         $msg .= "\t<td>" . $this->_clean_value($value) . "</td>\r\n";
                         $msg .= "</tr>\r\n";
                     } else {

--- a/class.formr.php
+++ b/class.formr.php
@@ -3880,9 +3880,15 @@ class Formr
                         $key = str_replace('_', ' ', ltrim($key, '_'));
                     }
 
+                    # if key is an array, print all values
+
+                    if (is_array($value)) {
+                      $value = implode("; ",$value);
+                    }
+
                     if ($html) {
                         $msg .= "<tr>\r\n";
-                        $msg .= "\t<td>$key</td>\r\n";
+                        $msg .= "\t<td><strong>$key</strong></td>\r\n";
                         $msg .= "\t<td>" . $this->_clean_value($value) . "</td>\r\n";
                         $msg .= "</tr>\r\n";
                     } else {


### PR DESCRIPTION
When sending form values in the send_email function, if multiple items are selected (for example, in a multiselect), only the last chosen value gets sent in the email. This change combines the values, separated by semicolons, and sends the combined value.