### PR TITLE
checkboxes and radios are now checked if using session values

### DIFF
--- a/class.formr.php
+++ b/class.formr.php
@@ -2385,16 +2385,17 @@ class Formr
         # open the element
         $return = '<input';
 
-        # populate the field's value (on page load) with the session value
-        if ($data['value'] == '' && $this->session_values && $this->session && !empty($_SESSION[$this->session][$data['name']])) {
-            $data['value'] = $_SESSION[$this->session][$data['name']];
-        }
 
         # if there are form errors, let's insert the posted value into
         # the array so the user doesn't have to enter the value again.
         # also, don't store passwords; always make the user re-type the password.
 
         if (!in_array($data['type'], $this->_input_types('checkbox'))) {
+
+            # populate the field's value (on page load) with the session value
+            if ($data['value'] == '' && $this->session_values && $this->session && !empty($_SESSION[$this->session][$data['name']])) {
+                $data['value'] = $_SESSION[$this->session][$data['name']];
+            }
 
             # an ID wasn't specified, let's create one using the name
             if (empty($data['id'])) {
@@ -2438,6 +2439,11 @@ class Formr
         } else {
 
             # checkboxes and radios..
+
+            # check the radio or checkbox (on page load) if field's value equals the session value
+            if ($this->session_values && $this->session && !empty($_SESSION[$this->session][$data['name']]) && $data['value'] == $_SESSION[$this->session][$data['name']]) {
+                $data['selected'] ='checked';
+            }
 
             # an ID wasn't specified, let's create one using the value
             if (empty($data['id'])) {


### PR DESCRIPTION
Session values for checkboxes and radios were being handled the same way as other fields, but since checkboxes and radios always have a set value they would never be shown as checked on the frontend when using session values. I moved the lines that handle session values for fields other than checkboxes and radios and created a new way to handle session values for radios and checkboxes. Now checkboxes and radios work as expected when using session values.