### PR TITLE
Fastform: use name and value to create hidden inputs

### DIFF
--- a/class.formr.php
+++ b/class.formr.php
@@ -4473,7 +4473,7 @@ class Formr
             {
                 # we're putting the hidden fields into an array and
                 # printing them at the end of the form
-                array_push($hidden, $this->input_hidden($data));
+                array_push($hidden, $this->input_hidden($data['name'], $data['value']));
             }
             elseif ($data['type'] == 'label')
             {


### PR DESCRIPTION
When passing an array to the `input_hidden` method, it creates one input per key/value pair. When using FastForm, the hidden inputs are created by passing the whole `$data` array to the `input_hidden` method. This creates multiple hidden inputs for unnecesary keys inside the `$data` array.

This PR makes it so this doesn't happen when creating hidden inputs with FastForm when using a multidimensional array. Also, you can now create hidden inputs like you do any other inputs in the array

Before:

```php
$inputs = [
  'hidden_id' => [
    'name' => 'user_id',
    'value' => '123'
  ]
];

require_once 'Formr/class.formr.php';
$form = new Formr\Formr();
$form->fastform($inputs);
```

This would print:

```html
<input type="hidden" name="name" id="name" value="user_id">
<input type="hidden" name="value" id="value" value="123">
<input type="hidden" name="id" id="id" value="">
<input type="hidden" name="string" id="string" value="">
<input type="hidden" name="label" id="label" value="">
<input type="hidden" name="inline" id="inline" value="">
<input type="hidden" name="selected" id="selected" value="">
<input type="hidden" name="options" id="options" value="">
<input type="hidden" name="fastform" id="fastform" value="1">
```

After:

```html
<input type="hidden" name="user_id" id="user_id" value="123">
```