### PR TITLE
Fix conditional order so that datetime and datetime_local can be used

### DIFF
--- a/class.formr.php
+++ b/class.formr.php
@@ -4532,12 +4532,12 @@ class Formr
             $data['type'] = 'color';
         } elseif ($this->_starts_with($key, 'email')) {
             $data['type'] = 'email';
-        } elseif ($this->_starts_with($key, 'date')) {
-            $data['type'] = 'date';
-        } elseif ($this->_starts_with($key, 'datetime')) {
-            $data['type'] = 'datetime';
         } elseif ($this->_starts_with($key, 'datetime_local')) {
             $data['type'] = 'datetime_local';
+        } elseif ($this->_starts_with($key, 'datetime')) {
+            $data['type'] = 'datetime';
+        } elseif ($this->_starts_with($key, 'date')) {
+            $data['type'] = 'date';
         } elseif ($this->_starts_with($key, 'month')) {
             $data['type'] = 'month';
         } elseif ($this->_starts_with($key, 'number')) {


### PR DESCRIPTION
The order of the conditionals caused an early match to date, keeping datetime and datetime_local from being evaluated. It was making it impossible to create datetime fields that could be populated with a date using fastform().