### PR TITLE
bug fix, default submit was using class of previous element if not default class

### DIFF
--- a/class.formr.php
+++ b/class.formr.php
@@ -4345,6 +4345,7 @@ class Formr
             $data['inline'] = '';
             $data['selected'] = '';
             $data['options'] = '';
+	    $data['class'] = '';
             
             $item = $this->input_submit($data);
             $return .= $this->_wrapper($item, $data);


### PR DESCRIPTION
This was replicate-able through:

`
	    $formr = new \Formr\Formr('bootstrap');
	    echo $formr->fastform([
	    'text1' => [
		'name' => 'title',
		'label' => 'Title',
	    ],
	    'text2' => [
		'name' => 'tags',
		'label' => 'Tags',
	    ],
	    'textarea1' => [
		'name' => 'description',
		'label' => 'Description',
		'class' => 'test',
	    ]
	]);

`

