### PR TITLE
Fix for Issue 149

### DIFF
--- a/class.formr.php
+++ b/class.formr.php
@@ -4470,10 +4470,6 @@ class Formr
                 $data['options'] = '';
             }
 
-            # hidden types don't really require an id, so we'll insert the id into the value
-            if ($data['type'] == 'hidden') {
-                $data['value'] = $data['id'];
-            }
         } else {
 
             # determine the field's type

--- a/lib/wrappers/bulma.php
+++ b/lib/wrappers/bulma.php
@@ -76,7 +76,7 @@ trait Bulma
             if($this->formr->use_element_wrapper_div) {
                 $return .= '<div class="field">' . $this->nl;
             }
-            $return .=   $data['label'] ? '' : '<label class="label">' . $data['label'] . '</label>' . $this->nl;
+            $return .=   $data['label'] ? '<label class="label">' . $data['label'] . '</label>' . $this->nl : '';
             $return .= '  <div class="file">' . $this->nl;
             $return .= '    <label class="file-label">' . $this->nl;
             $return .=       $element . $this->nl;
@@ -103,7 +103,7 @@ trait Bulma
             if($this->formr->use_element_wrapper_div) {
                 $return .= '<div class="field">' . $this->nl;
             }
-            $return .=   $data['label'] ? '' : '<label class="label">' . $data['label'] . '</label>' . $this->nl;
+            $return .=   $data['label'] ? '<label class="label">' . $data['label'] . '</label>' . $this->nl : '';
             $return .= '  <div class="control">' . $this->nl;
             $return .= '    <div class="select">' . $this->nl;
             $return .=       $element . $this->nl;


### PR DESCRIPTION
It seems ok to simply remove this code which is overwriting the value of a hidden field with the id property. For fastform(), It results in the name and id property being both set to the first value passed in and ignores the second, but does set the value correctly which it would set no value with the removed code still in place. 

'hidden2' => "campaignId1,campaignId2,$this->campaignId",
produces:
`<input type="hidden" name="campaignId1" id="campaignId1" value="20">`